### PR TITLE
fix: Correct CSS class names in SchedulerCalendar to restore grid layout

### DIFF
--- a/teacher-scheduler-app/src/components/SchedulerCalendar.tsx
+++ b/teacher-scheduler-app/src/components/SchedulerCalendar.tsx
@@ -155,17 +155,17 @@ const SchedulerCalendar: React.FC = () => {
       {/* Calendar Grid */}
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="scheduler-calendar">
-          <div className="day-row header-row">
-            <div className="time-cell header-cell">Time</div>
+          <div className="header-row">
+            <div className="time-col-header">Time</div>
             {DAYS_OF_WEEK.map((day) => (
-              <div key={day} className="day-header header-cell">
+              <div key={day} className="day-header-cell">
                 {day}
               </div>
             ))}
           </div>
           {TIME_SLOTS.map((timeSlot) => (
-            <div key={timeSlot} className="day-row">
-              <div className="time-cell">{timeSlot}</div>
+            <div key={timeSlot} className="time-row">
+              <div className="time-header-cell">{timeSlot}</div>
               {DAYS_OF_WEEK.map((day) => {
                 const droppableId = `cell-${day}-${timeSlot}`;
                 const classesInSlot = currentFilteredClasses.filter((scheduledClass) => {
@@ -184,7 +184,7 @@ const SchedulerCalendar: React.FC = () => {
                   <Droppable droppableId={droppableId} key={droppableId}>
                     {(provided, snapshot) => (
                       <div
-                        className={`day-cell ${snapshot.isDraggingOver ? 'dragging-over' : ''}`}
+                        className={`calendar-cell ${snapshot.isDraggingOver ? 'dragging-over' : ''}`}
                         ref={provided.innerRef}
                         {...provided.droppableProps}
                       >


### PR DESCRIPTION
Fixed critical bug where schedule calendar was displaying as a single cell instead of proper grid. Changed incorrect CSS class names to match the existing SchedulerCalendar.css definitions:

- Changed 'day-row header-row' to 'header-row'
- Changed 'time-cell header-cell' to 'time-col-header'
- Changed 'day-header header-cell' to 'day-header-cell'
- Changed 'day-row' to 'time-row'
- Changed 'time-cell' to 'time-header-cell'
- Changed 'day-cell' to 'calendar-cell'

These class names now properly match the flexbox grid layout defined in SchedulerCalendar.css.

🤖 Generated with [Claude Code](https://claude.com/claude-code)